### PR TITLE
Update Turkish translations

### DIFF
--- a/client/src/translations.json
+++ b/client/src/translations.json
@@ -1379,18 +1379,18 @@
   "tr": {
     "no": "HAYIR",
     "yes": "EVET",
-    "is": "İçin Yılbaşı oldu",
-    "until": "Yılbaşı gününe kadar",
+    "is": "Şu kadar süredir yeni yıldayız: ",
+    "until": "kaldı",
     "language": "Turkish",
     "month": "ay",
     "months": "ay",
     "day": "gün",
-    "days": "günler",
+    "days": "gün",
     "hour": "saat",
-    "hours": "saatler",
+    "hours": "saat",
     "minute": "dakika",
     "minutes": "dakika",
-    "second": "ikinci",
+    "second": "saniye",
     "seconds": "saniye"
   },
   "uk": {


### PR DESCRIPTION
The "until" message sadly can't mention new year's day and just means "[this much time] left.".