### PR TITLE
Fixed issue with YES/NO if language not supported

### DIFF
--- a/client/src/components/CountDown.vue
+++ b/client/src/components/CountDown.vue
@@ -34,7 +34,7 @@ function getLanguage(override) {
 const language = getLanguage();
 // eslint-disable-next-line
 console.log('Detected language:', language);
-const yesNoTranslation = allTranslations[language] || translations.en;
+const yesNoTranslation = allTranslations[language] || allTranslations.en;
 const formatDuration = translations[language] || translations.en;
 
 export default {


### PR DESCRIPTION
If a language was not supported, it would look at ```translations.en``` for a yes or no property however this was the time format file, and did not contain the yes or no property; which meant if your language was not supported it would show undefined instead of the correct answer. 

Updated it to look into the ```allTranslations``` file if the language is not support to get the default response of YES or NO.