### PR TITLE
Possible differentiation between grammar styles

### DIFF
--- a/client/src/translations.json
+++ b/client/src/translations.json
@@ -206,7 +206,7 @@
   "de": {
     "no": "NEIN",
     "yes": "JA",
-    "is": "Es ist Silvester für",
+    "is": "Seit $time$ ist es Silvester",
     "until": "bis Silvester",
     "language": "German",
     "month": "Monat",


### PR DESCRIPTION
This could potentially be a solution for different grammar (and therefor word orders) in different languages.

This is not a finished solution and does not work yet (since it is not implemented) but rather under "needs work".

I added an example of the correct german translation for the Sentence: "it has been new years day for 12 hours bla bla bla..."
In German, this should be "Seit 12 Stunden (bla bla bla) ist es Silvester."
with the Time being in the middle of the sentence.

I, unfortunately, do not have time now to implement the solution into the code for now (also german does not work for me on the website - so this should need some more changes)
but I thought that the process of creating the text could be something like this (pseudocode):

    Read language translation file in
    select language based on browser

    insert translations into the website:
      if (translation contains $time$)
        Write sentence.Replace("$time$",timeTranslation)
      else
        Write sentence + " " +timeTranslation

Therefore not every translation should need a $time$