### PR TITLE
Differentiation in languages with arguments and special time translations [Updated]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,6 @@ dist
 
 # Stores VSCode versions used for testing VSCode extensions
 .vscode-test
+
+# Jetbrains
+.idea/

--- a/client/src/components/CountDown.vue
+++ b/client/src/components/CountDown.vue
@@ -34,7 +34,9 @@ function getLanguage(override) {
 const language = getLanguage();
 // eslint-disable-next-line
 console.log('Detected language:', language);
+// read in lanuage from translations.json
 const translationDb = allTranslations[language] || translations.en;
+// load translation function from translation/index.js --> default translate function
 const specialTranslation = translations[language] || translations.translate;
 
 export default {
@@ -47,13 +49,16 @@ export default {
 
     const durationProps = ['months', 'days', 'hours', 'minutes', 'seconds'];
 
+    // calls functions in translations/index.js with correct arguments
     function createTimeString(values) {
+      // if specialtranslation is default, call with two arguments
       if (specialTranslation === translations.translate) {
         return specialTranslation({
           translation: translationDb,
           timevalues: values,
         });
       }
+      // otherwise call with one argument object
       return specialTranslation(values);
     }
 
@@ -63,9 +68,13 @@ export default {
       let newYearsDay = DateTime.local(now.year, 1, 1);
 
       isNewYearsDay.value = now.hasSame(newYearsDay, 'day');
+
       if (isNewYearsDay.value) {
+        // set time string to translated text
         timeTranslation.value = createTimeString(newYearsDay.diffNow(durationProps));
+        // if used method is default
         if (specialTranslation === translations.translate) {
+          // replace possibly the $time$ string
           if (translationDb.is.includes('$time$')) {
             timeTranslation.value = translationDb.is.replace(/\$time\$/g, timeTranslation.value);
           } else {
@@ -77,8 +86,12 @@ export default {
         favicon.href = 'fireworks-favicon.png';
       } else {
         newYearsDay = DateTime.local(now.year + 1, 1, 1);
+
+        // set time string to translated text
         timeTranslation.value = createTimeString(newYearsDay.diffNow(durationProps));
+        // if standard translate function was used
         if (specialTranslation === translations.translate) {
+          // replace possibly the $time$ function
           if (translationDb.until.includes('$time$')) {
             timeTranslation.value = translationDb.until.replace(/\$time\$/g, timeTranslation.value);
           } else {

--- a/client/src/components/CountDown.vue
+++ b/client/src/components/CountDown.vue
@@ -53,15 +53,23 @@ export default {
       let newYearsDay = DateTime.local(now.year, 1, 1);
       isNewYearsDay.value = now.hasSame(newYearsDay, 'day');
       if (isNewYearsDay.value) {
-        timeTranslation.value = formatDuration(newYearsDay.diffNow(durationProps));
+        timeTranslation.value = yesNoTranslation.is;
+
         document.title = yesNoTranslation.yes;
         favicon.href = 'fireworks-favicon.png';
       } else {
         newYearsDay = DateTime.local(now.year + 1, 1, 1);
-        timeTranslation.value = formatDuration(newYearsDay.diffNow(durationProps));
+
+        timeTranslation.value = yesNoTranslation.until;
         // timeTranslation.value = newYearsDay.diffNow(durationProps);
         document.title = yesNoTranslation.no;
         favicon.href = 'x-favicon.png';
+      }
+      if(timeTranslation.value.include("$time$")) {
+        timeTranslation.value = timeTranslation.value.replace(/\$time\$/g, newYearsDay.diffNow(durationProps));
+      }
+      else {
+        timeTranslation.value = timeTranslation.value + "\n" + newYearsDay.diffNow(durationProps);
       }
 
       setTimeout(updateClock, 500);

--- a/client/src/translations.json
+++ b/client/src/translations.json
@@ -1380,7 +1380,7 @@
     "no": "HAYIR",
     "yes": "EVET",
     "is": "Şu kadar süredir yeni yıldayız: ",
-    "until": "kaldı",
+    "until": "Yılbaşına $time$ kaldı!",
     "language": "Turkish",
     "month": "ay",
     "months": "ay",

--- a/client/src/translations.json
+++ b/client/src/translations.json
@@ -206,7 +206,7 @@
   "de": {
     "no": "NEIN",
     "yes": "JA",
-    "is": "Es ist Silvester für",
+    "is": "Seit $time$ ist es Silvester",
     "until": "bis Silvester",
     "language": "German",
     "month": "Monat",

--- a/client/src/translations/index.js
+++ b/client/src/translations/index.js
@@ -1,15 +1,5 @@
 const roundValue = value => Math.floor(Math.abs(value));
 
-const translateTimeAllPlural = ({
-  translations,
-  values,
-}) => Object.entries(values)
-  .reduce((all, [prop, value]) => {
-    if (!value) return all;
-    const unit = translations[prop];
-    return `${all} ${roundValue(value)} ${unit}`;
-  }, '');
-
 const translateCommonWithPlural = ({
   translations,
   values,
@@ -23,107 +13,23 @@ const translateCommonWithPlural = ({
     return `${all} ${roundValue(value)} ${unit}`;
   }, '');
 
-const english = ({
-  isNewYearsDay,
-  months,
-  days,
-  hours,
-  minutes,
-  seconds,
+const standardTranslate = ({
+  translation,
+  timevalues,
 }) => {
-  const timeLeft = translateCommonWithPlural({
-    translations: {
-      months: 'months',
-      days: 'days',
-      hours: 'hours',
-      minutes: 'minutes',
-      seconds: 'seconds',
-      month: 'month',
-      day: 'day',
-      hour: 'hour',
-      minute: 'minute',
-      second: 'second',
-    },
-    values: {
-      months,
-      days,
-      hours,
-      minutes,
-      seconds,
-    },
-  });
-
-  if (isNewYearsDay) {
-    return `It has been New Year's day for${timeLeft}`;
+  if (timevalues !== undefined) {
+    return translateCommonWithPlural({
+      translations: translation,
+      values: {
+        months: timevalues.months,
+        days: timevalues.days,
+        hours: timevalues.hours,
+        minutes: timevalues.minutes,
+        seconds: timevalues.seconds,
+      },
+    });
   }
-  return `${timeLeft} until New Year's day`;
-};
-
-const turkish = ({
-  isNewYearsDay,
-  months,
-  days,
-  hours,
-  minutes,
-  seconds,
-}) => {
-  const translatedTime = translateTimeAllPlural({
-    translations: {
-      months: 'ay',
-      days: 'gün',
-      hours: 'saat',
-      minutes: 'dakika',
-      seconds: 'saniye',
-    },
-    values: {
-      months,
-      days,
-      hours,
-      minutes,
-      seconds,
-    },
-  });
-
-  if (isNewYearsDay) {
-    return `Şu kadar süredir yeni yıldayız:${translatedTime}`;
-  }
-  return `Yılbaşına${translatedTime} kaldı!`;
-};
-
-const danish = ({
-  isNewYearsDay,
-  months,
-  days,
-  hours,
-  minutes,
-  seconds,
-}) => {
-  const timeLeft = translateCommonWithPlural({
-    translations: {
-      months: 'måneder',
-      month: 'måned',
-      days: 'dage',
-      day: 'dag',
-      hours: 'timer',
-      hour: 'time',
-      minutes: 'minutter',
-      minute: 'minut',
-      seconds: 'sekunder',
-      second: 'sekund',
-    },
-    values: {
-      months,
-      days,
-      hours,
-      minutes,
-      seconds,
-    },
-  });
-
-  if (isNewYearsDay) {
-    return `Det har været nytårsdag i${timeLeft}`;
-  }
-  return `${timeLeft} indtil det er nytårsaften`;
+  return 'undefined';
 };
 
 const russian = ({
@@ -135,7 +41,6 @@ const russian = ({
   seconds,
 }) => {
   let timeLeft = '';
-
   if (months > 0) {
     timeLeft += months;
     if (months === 1) {
@@ -151,7 +56,8 @@ const russian = ({
     timeLeft += days;
     if (days % 10 === 1 && days !== 11) {
       timeLeft += ' день ';
-    } else if (days % 10 < 5 && days !== 0 && (days % 100 > 19 || days % 100 < 10) && days % 10 !== 0) {
+    } else if (days % 10 < 5 && days !== 0 && (days % 100 > 19
+      || days % 100 < 10) && days % 10 !== 0) {
       timeLeft += ' дня ';
     } else {
       timeLeft += ' дней ';
@@ -162,7 +68,8 @@ const russian = ({
     timeLeft += hours;
     if (hours % 10 === 1 && hours !== 11) {
       timeLeft += ' час ';
-    } else if (hours % 10 < 5 && hours !== 0 && (hours % 100 > 19 || hours % 100 < 10) && hours % 10 !== 0) {
+    } else if (hours % 10 < 5 && hours !== 0 && (hours % 100 > 19
+      || hours % 100 < 10) && hours % 10 !== 0) {
       timeLeft += ' часа ';
     } else {
       timeLeft += ' часов ';
@@ -173,19 +80,21 @@ const russian = ({
     timeLeft += minutes;
     if (minutes % 10 === 1 && minutes !== 11) {
       timeLeft += ' минуту ';
-    } else if (minutes % 10 < 5 && minutes !== 0 && (minutes % 100 > 19 || days % 100 < 10) && days % 10 !== 0) {
+    } else if (minutes % 10 < 5 && minutes !== 0 && (minutes % 100 > 19
+      || days % 100 < 10) && days % 10 !== 0) {
       timeLeft += ' минуты ';
     } else {
       timeLeft += ' минут ';
     }
   }
-  
+
   const secondsVal = roundValue(seconds);
   if ((secondsVal > 0) || (secondsVal === 0 && timeLeft)) {
     timeLeft += secondsVal;
     if (secondsVal % 10 === 1 && secondsVal !== 11) {
       timeLeft += ' секунду';
-    } else if (secondsVal % 10 < 5 && secondsVal !== 0 && (secondsVal % 100 > 19 || secondsVal % 100 < 10) && secondsVal % 10 !== 0) {
+    } else if (secondsVal % 10 < 5 && secondsVal !== 0 && (secondsVal % 100 > 19
+      || secondsVal % 100 < 10) && secondsVal % 10 !== 0) {
       timeLeft += ' секунды';
     } else {
       timeLeft += ' секунд';
@@ -200,8 +109,6 @@ const russian = ({
 
 // key is the language code. See src/translations.json for language codes
 module.exports = {
-  en: english,
-  da: danish,
-  tr: turkish,
-  ru: russian,
+  de: russian,
+  translate: standardTranslate,
 };

--- a/client/src/translations/index.js
+++ b/client/src/translations/index.js
@@ -107,6 +107,6 @@ const russian = ({
 
 // key is the language code. See src/translations.json for language codes
 module.exports = {
-  de: russian,
+  ru: russian,
   translate: standardTranslate,
 };

--- a/client/src/translations/index.js
+++ b/client/src/translations/index.js
@@ -17,19 +17,17 @@ const standardTranslate = ({
   translation,
   timevalues,
 }) => {
-  if (timevalues !== undefined) {
-    return translateCommonWithPlural({
-      translations: translation,
-      values: {
-        months: timevalues.months,
-        days: timevalues.days,
-        hours: timevalues.hours,
-        minutes: timevalues.minutes,
-        seconds: timevalues.seconds,
-      },
-    });
-  }
-  return 'undefined';
+  return translateCommonWithPlural({
+    translations: translation,
+    values: {
+      months: timevalues.months,
+      days: timevalues.days,
+      hours: timevalues.hours,
+      minutes: timevalues.minutes,
+      seconds: timevalues.seconds,
+    },
+  });
+
 };
 
 const russian = ({


### PR DESCRIPTION
Wait no more,

I sat down and changed the client site as I would imagine it and rewrote the `CountDown.vue` and 
the `translations/index.js`.

The standard `$time$` argument will be automatically replaced if present and if there is no special translation function in the `ìndex.js`. Now the translation for Russian still uses the special time translation,
turkish or german for example are using the $time$ argument (which is quite shorter).

Will update the pulll request on recent changes if wanted